### PR TITLE
feat: add a tree view for commands

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Attach to Suspended",
+			"type": "node",
+			"request": "attach",
+			"port": 9229
+		  },
+	]
+}

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -1,0 +1,32 @@
+import {CliUx, Interfaces} from '@oclif/core'
+import {Tree} from '@oclif/core/lib/cli-ux/styled/tree'
+
+const addNodes = (tree: Tree, commandParts: string[]) => {
+  const existingNode = tree.search(commandParts[0])
+
+  // If the node exists and there's another part, add it to the node
+  if (existingNode && commandParts[1]) {
+    addNodes(existingNode as Tree, commandParts.slice(1))
+  } else {
+    // The node doesn't exist, create it
+    tree.insert(commandParts[0])
+
+    // If there are more parts, add them to the node
+    if (commandParts.length > 1) {
+      addNodes(tree.search(commandParts[0]) as Tree, commandParts.slice(1))
+    }
+  }
+}
+
+const createCommandTree = (commands: Interfaces.Command[], topicSeparator = ':') => {
+  const tree = CliUx.ux.tree()
+
+  commands.forEach(command => {
+    const commandParts = command.id.split(topicSeparator)
+    addNodes(tree, commandParts)
+  })
+
+  return tree
+}
+
+export default createCommandTree


### PR DESCRIPTION
## What does this PR do?
Adds the `--tree` flag to the `commands` command.
This will print out a tree like structure for all of the commands in a CLI.

## Testing instructions
1. Pull this branch
1. Run `yarn install` and `yarn build`
1. At the root of this repo run
    1. Using the `sf` cli:
        1. `sf plugins link .`
        1. `sf commands --tree`
    1. Using the `sfdx` cli:
        1. `sfdx plugins:link .`
        1. `sfdx commands --tree`
1. Verify the command tree.

## Examples
#### Normal tree
![sfCommandsTree](https://user-images.githubusercontent.com/1084688/172248421-92425b51-4e8a-42e7-9317-fc705a43d860.gif)
#### `--json` tree
![sfCommandsTreeJson](https://user-images.githubusercontent.com/1084688/172248573-19f5228b-3845-4522-ae93-dedd2162fa65.gif)

@W-10673592@