### PR TITLE
fix: deduplicate json output

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -57,7 +57,7 @@ export default class Commands extends Command {
         // If Command classes have circular references, don't break the commands command.
         return this.removeCycles(obj)
       }))
-      return formatted
+      return _.uniqBy(formatted, 'id')
     }
 
     if (flags.tree) {


### PR DESCRIPTION
I don't know for sure where the duplication happens, but this fixes it before the command returns its json.

https://github.com/forcedotcom/cli/issues/1777
@W-11983167@