### PR TITLE
feat: omit deprecated commands and deprecates aliases

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -14,6 +14,7 @@ export default class Commands extends Command {
   static enableJsonFlag = true
 
   static flags = {
+    deprecated: Flags.boolean({description: 'show deprecated commands'}),
     help: Flags.help({char: 'h'}),
     hidden: Flags.boolean({description: 'show hidden commands'}),
     tree: Flags.boolean({description: 'show tree of commands'}),
@@ -23,8 +24,14 @@ export default class Commands extends Command {
   async run() {
     const {flags} = await this.parse(Commands)
     let commands = this.getCommands()
+
     if (!flags.hidden) {
       commands = commands.filter((c) => !c.hidden)
+    }
+
+    if (!flags.deprecated) {
+      const deprecatedAliases = new Set(commands.filter((c) => c.deprecateAliases).flatMap((c) => c.aliases))
+      commands = commands.filter((c) => c.state !== 'deprecated' && !deprecatedAliases.has(c.id))
     }
 
     const {config} = this


### PR DESCRIPTION
`sf commands` is quite lengthy because it includes all the deprecated commands and deprecated aliases of commands.

You'd now need to pass in `--deprecated` to see those, similar to how `--hidden` works.

some UT, including the new ones are asserting presence/absence of fragments of text rather than the full table output.

[@W-14736232@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001hLcIrYAK/view)

