### PR TITLE
Export command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
-export default {}
+import Commands from "./commands/commands.js";
+
+export const commands = {
+  commands: Commands
+}


### PR DESCRIPTION
This plugin should export its command (as plugin-plugins does) so that it can be imported explicitly from CLI's that need bundling.