### PR TITLE
fix: use lodash instead of lodash.template

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "bugs": "https://github.com/oclif/plugin-commands/issues",
   "dependencies": {
     "@oclif/core": "^3.26.5",
-    "lodash.pickby": "^4.6.0",
-    "lodash.sortby": "^4.7.0",
-    "lodash.template": "^4.5.0",
-    "lodash.uniqby": "^4.7.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^18",
@@ -17,10 +14,6 @@
     "@oclif/prettier-config": "^0.2.1",
     "@oclif/test": "^3.2.12",
     "@types/chai": "^4.3.11",
-    "@types/lodash.pickby": "^4.6.9",
-    "@types/lodash.sortby": "^4.7.9",
-    "@types/lodash.template": "^4.5.3",
-    "@types/lodash.uniqby": "^4.7.9",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18",
     "chai": "^4.4.1",

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,5 +1,5 @@
 import {Command, Flags, toConfiguredId, ux} from '@oclif/core'
-import {pickBy, sortBy, template, uniqBy} from 'lodash'
+import _ from 'lodash'
 import {EOL} from 'node:os'
 
 import createCommandTree from '../utils/tree.js'
@@ -32,13 +32,13 @@ export default class Commands extends Command {
     }
 
     const {config} = this
-    commands = sortBy(commands, 'id').map((command) => {
+    commands = _.sortBy(commands, 'id').map((command) => {
       // Template supported fields.
       command.description =
-        (typeof command.description === 'string' && template(command.description)({command, config})) || undefined
+        (typeof command.description === 'string' && _.template(command.description)({command, config})) || undefined
       command.summary =
-        (typeof command.summary === 'string' && template(command.summary)({command, config})) || undefined
-      command.usage = (typeof command.usage === 'string' && template(command.usage)({command, config})) || undefined
+        (typeof command.summary === 'string' && _.template(command.summary)({command, config})) || undefined
+      command.usage = (typeof command.usage === 'string' && _.template(command.usage)({command, config})) || undefined
       command.id = toConfiguredId(command.id, config)
       return command
     })
@@ -63,7 +63,7 @@ export default class Commands extends Command {
             // Object.assign from overwriting the properties on the object, we need to filter out the undefined values.
             Object.assign(
               obj,
-              pickBy(commandClass, (v) => v !== undefined),
+              _.pickBy(commandClass, (v) => v !== undefined),
             )
           }
 
@@ -74,7 +74,7 @@ export default class Commands extends Command {
           return this.removeCycles(obj)
         }),
       )
-      return uniqBy(formatted, 'id')
+      return _.uniqBy(formatted, 'id')
     }
 
     if (flags.tree) {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,8 +1,5 @@
 import {Command, Flags, toConfiguredId, ux} from '@oclif/core'
-import pickBy from 'lodash.pickby'
-import sortBy from 'lodash.sortby'
-import template from 'lodash.template'
-import uniqBy from 'lodash.uniqby'
+import {pickBy, sortBy, template, uniqBy} from 'lodash'
 import {EOL} from 'node:os'
 
 import createCommandTree from '../utils/tree.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2417,34 +2417,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash.pickby@^4.6.9":
-  version "4.6.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.pickby/-/lodash.pickby-4.6.9.tgz#b6d72b1adf8601aa76736f298adcbaa8f734b831"
-  integrity sha512-SPI248FYnyd3jOxDeJq2vX2UKQnDzqacuqdeOVqwE1MPSk8gN8TA3FcHSMQWLlpBnuHgXvgKInvywbOFbidpJA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.sortby@^4.7.9":
-  version "4.7.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.sortby/-/lodash.sortby-4.7.9.tgz#e4af00e03daece7a939378ff64f0d44e638d7db6"
-  integrity sha512-PDmjHnOlndLS59GofH0pnxIs+n9i4CWeXGErSB5JyNFHu2cmvW6mQOaUKjG8EDPkni14IgF8NsRW8bKvFzTm9A==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.template@^4.5.3":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@types/lodash.template/-/lodash.template-4.5.3.tgz#1174483eaa761a76a9d68c4adbee4c4e2742f329"
-  integrity sha512-Mo0UYKLu1oXgkV9TVoXZLlXXjyIXlW7ZQRxi/4gQJmzJr63dmicE8gG0OkPjYTKBrBic852q0JzqrtNUWLBIyA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.uniqby@^4.7.9":
-  version "4.7.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.uniqby/-/lodash.uniqby-4.7.9.tgz#10bacba9cf3263c6e07ae11d953de6ada6605104"
-  integrity sha512-rjrXji/seS6BZJRgXrU2h6FqxRVufsbq/HE0Tx0SdgbtlWr2YmD/M64BlYEYYlaMcpZwy32IYVkMfUMYlPuv0w==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash@*":
   version "4.14.199"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.199.tgz#c3edb5650149d847a277a8961a7ad360c474e9bf"
@@ -5187,20 +5159,10 @@ lodash.mergewith@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
   integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
-lodash.pickby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
-  integrity sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==
-
 lodash.snakecase@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
   integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
-
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-  integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
 lodash.startcase@^4.4.0:
   version "4.4.0"
@@ -5226,11 +5188,6 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
-
-lodash.uniqby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
-  integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
 
 lodash.upperfirst@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
Use `lodash` instead of `lodash.template` to fix security vulnerability.

Context: lodash no longer recommends per-method packages: https://lodash.com/per-method-packages

Fixes #661
@W-15703211@